### PR TITLE
Update Gettext usage to address deprecation warnings

### DIFF
--- a/lib/phoenix_analytics/web/components/core_components.ex
+++ b/lib/phoenix_analytics/web/components/core_components.ex
@@ -2,9 +2,9 @@ defmodule PhoenixAnalytics.Web.CoreComponents do
   @moduledoc false
 
   use Phoenix.Component
+  use Gettext, backend: PhoenixAnalytics.Web.Gettext
 
   alias Phoenix.LiveView.JS
-  import PhoenixAnalytics.Web.Gettext
 
   @doc """
   Renders a modal.

--- a/lib/phoenix_analytics/web/gettext.ex
+++ b/lib/phoenix_analytics/web/gettext.ex
@@ -1,5 +1,5 @@
 defmodule PhoenixAnalytics.Web.Gettext do
   @moduledoc false
 
-  use Gettext, otp_app: :phoenix_analytics
+  use Gettext.Backend, otp_app: :phoenix_analytics
 end

--- a/priv/repo/dev.exs
+++ b/priv/repo/dev.exs
@@ -1,7 +1,7 @@
 #!/usr/bin/env elixir
 Mix.install([
   {:phoenix_playground, "~> 0.1.5"},
-  {:phoenix_analytics, path: "../phoenix_analytics", force: true}
+  {:phoenix_analytics, path: ".", force: true}
 ])
 
 IO.puts("DUCK_PATH: #{System.get_env("DUCK_PATH")}")

--- a/priv/repo/dev.exs
+++ b/priv/repo/dev.exs
@@ -95,7 +95,8 @@ end
 PhoenixPlayground.start(
   plug: DevRouter,
   endpoint_options: [
-    secret_key_base: "gpaTilt0aZo38EYNrPqIA8rNGhsuysCMe8GxMps6/HZQ3xnjtIiG0UyKIHBaI+FM"
+    secret_key_base: "gpaTilt0aZo38EYNrPqIA8rNGhsuysCMe8GxMps6/HZQ3xnjtIiG0UyKIHBaI+FM",
+    ip: {0, 0, 0, 0},
   ],
   open_browser: false,
   child_specs: []


### PR DESCRIPTION
## Description

This PR updates our Gettext implementation to address deprecation warnings and align with the latest best practices recommended by the Gettext library.

## Changes

- Updated `lib/phoenix_analytics/web/gettext.ex` to use `Gettext.Backend`
- Modified modules using Gettext to use the new `use Gettext, backend: ...` syntax

## Additional Notes

This change should be backwards compatible, but it's recommended to thoroughly test internationalization features after merging.